### PR TITLE
Here's how I'm attempting to fix the CI dependency fetching for `nih_…

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [net]
 git-fetch-with-cli = true
+git-url-insteadof = "git://github.com/,https://github.com/"

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -13,6 +13,10 @@ jobs:
   build_and_test:
     name: Build and Test
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      GIT_TRACE: "1"
+      GIT_CURL_VERBOSE: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,14 +26,22 @@ jobs:
         with:
           components: rustfmt, clippy # Add other components like 'llvm-tools-preview' if needed later
 
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Optional: specify a cache key prefix if you have multiple workflows
-          # prefix-key: "my-workflow-specific-prefix"
-          # Optional: share the cache between jobs (if you had multiple jobs in this workflow)
-          # shared-key: "shared-cache-key"
-          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on pushes to main
+#      - name: Cache Cargo dependencies
+#        uses: Swatinem/rust-cache@v2
+#        with:
+#          # Optional: specify a cache key prefix if you have multiple workflows
+#          # prefix-key: "my-workflow-specific-prefix"
+#          # Optional: share the cache between jobs (if you had multiple jobs in this workflow)
+#          # shared-key: "shared-cache-key"
+#          save-if: ${{ github.ref == 'refs/heads/main' }} # Only save cache on pushes to main
+
+      - name: Clear Cargo cache
+        run: |
+          echo "Clearing Cargo registry cache..."
+          rm -rf ~/.cargo/registry
+          echo "Clearing Cargo git checkout cache..."
+          rm -rf ~/.cargo/git
+          echo "Cache clearing complete."
 
       - name: Update crate index
         run: cargo update --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later" # SPDX identifier for GPLv3
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", rev = "f678c9de6ea81e07818cc7902f71668112f5f13A", features = ["serde"] }
+nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", branch = "main", features = ["serde"] }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
…plug`:

I've made several changes to address issues with fetching the `nih_plug` git dependency in your GitHub Actions CI:

- I modified `Cargo.toml` to use `branch = "main"` for `nih_plug` instead of a specific revision.
- I updated `.cargo/config.toml` to include `git-fetch-with-cli = true` and force git URLs to HTTPS.
- I added verbose git logging (`GIT_TRACE=1`, `GIT_CURL_VERBOSE=1`) to your CI workflow.
- I added a step to clear `~/.cargo/registry` and `~/.cargo/git` caches in your CI workflow.
- I temporarily disabled the `Swatinem/rust-cache@v2` action to rule out interference.

My goal is to ensure your CI can reliably fetch and build the project dependencies.