### PR TITLE
docs(readme): Improve signal path diagram layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,30 @@ This project is developed as a **standalone application first**, ensuring a stab
 The application's audio processing is designed for high-fidelity and low latency, following a clean and logical signal path.
 
 ```mermaid
-graph TD
+graph LR
     %% ---- Control Plane ----
-    subgraph "User Controls & File Loading"
-        direction LR
-        UI["fa:fa-desktop User Interface (egui)"]
-        SofaLoader["fa:fa-file-audio SOFA File Loader"]
-        AutoEqLoader["fa:fa-file-import AutoEQ Profile Loader"]
-    end
+    subgraph "Control Plane"
+        direction TB
+        
+        subgraph "User Controls & File Loading"
+            direction LR
+            UI["fa:fa-desktop User Interface (egui)"]
+            SofaLoader["fa:fa-file-audio SOFA File Loader"]
+            AutoEqLoader["fa:fa-file-import AutoEQ Profile Loader"]
+        end
 
-    subgraph "Configuration"
-        Params["fa:fa-sliders-h Plugin Parameters"]
-    end
+        subgraph "Configuration"
+            Params["fa:fa-sliders-h Plugin Parameters"]
+        end
 
-    UI -- "Modifies & Triggers" --> Params
-    UI -- "Triggers" --> SofaLoader
-    UI -- "Triggers" --> AutoEqLoader
+        UI -- "Modifies & Triggers" --> Params
+        UI -- "Triggers" --> SofaLoader
+        UI -- "Triggers" --> AutoEqLoader
+    end
 
     %% ---- Real-time Audio Signal Path ----
     subgraph "Signal Path"
-        direction LR
+        direction TB
         Input["fa:fa-volume-down Stereo Input"] --> EQ["fa:fa-wave-square Headphone EQ"] --> Conv["fa:fa-headphones-alt Binaural Convolution"] --> Gain["fa:fa-volume-up Output Gain"] --> Output["fa:fa-headphones Stereo Output"]
     end
 
@@ -75,6 +79,10 @@ graph TD
     class Input,Output io
     class EQ,Conv,Gain dsp
     class UI,Params,SofaLoader,AutoEqLoader control
+
+    %% ---- Link Styling ----
+    linkStyle 2,3,4 stroke:#84cc16,stroke-width:2px,stroke-dasharray: 3 3
+    linkStyle 9,10,11,12,13 stroke:#ffb700,stroke-width:2px
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ graph LR
     class UI,Params,SofaLoader,AutoEqLoader control
 
     %% ---- Link Styling ----
-    linkStyle 2,3,4 stroke:#84cc16,stroke-width:2px,stroke-dasharray: 3 3
-    linkStyle 9,10,11,12,13 stroke:#ffb700,stroke-width:2px
+    linkStyle 0,1,2 stroke:#84cc16,stroke-width:2px,stroke-dasharray: 3 3
+    linkStyle 7,8,9,10,11 stroke:#ffb700,stroke-width:2px
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -38,37 +38,36 @@ The application's audio processing is designed for high-fidelity and low latency
 
 ```mermaid
 graph TD
-    subgraph "User Interface & Control"
+    %% ---- Control Plane ----
+    subgraph "User Controls & File Loading"
         direction LR
         UI["fa:fa-desktop User Interface (egui)"]
-        Params["fa:fa-sliders-h Plugin Parameters"]
         SofaLoader["fa:fa-file-audio SOFA File Loader"]
         AutoEqLoader["fa:fa-file-import AutoEQ Profile Loader"]
-
-        UI -- "Modifies" --> Params
-        UI -- "Triggers" --> SofaLoader
-        UI -- "Triggers" --> AutoEqLoader
     end
 
-    subgraph "Real-time Audio Signal Path"
-        direction TB
-        Input["fa:fa-volume-down Stereo Audio Input"]
-        EQ["fa:fa-wave-square Headphone EQ"]
-        Conv["fa:fa-headphones-alt Binaural Convolution"]
-        Gain["fa:fa-volume-up Output Gain"]
-        Output["fa:fa-headphones Stereo Audio Output"]
-
-        Input --> EQ --> Conv --> Gain --> Output
+    subgraph "Configuration"
+        Params["fa:fa-sliders-h Plugin Parameters"]
     end
 
-    %% Connections between subgraphs
+    UI -- "Modifies & Triggers" --> Params
+    UI -- "Triggers" --> SofaLoader
+    UI -- "Triggers" --> AutoEqLoader
+
+    %% ---- Real-time Audio Signal Path ----
+    subgraph "Signal Path"
+        direction LR
+        Input["fa:fa-volume-down Stereo Input"] --> EQ["fa:fa-wave-square Headphone EQ"] --> Conv["fa:fa-headphones-alt Binaural Convolution"] --> Gain["fa:fa-volume-up Output Gain"] --> Output["fa:fa-headphones Stereo Output"]
+    end
+
+    %% ---- Control Connections to Signal Path ----
     Params -- "Controls" --> EQ
     Params -- "Controls" --> Conv
     Params -- "Controls" --> Gain
     SofaLoader -- "Provides HRTFs" --> Conv
     AutoEqLoader -- "Provides Settings" --> EQ
 
-    %% Styling
+    %% ---- Styling ----
     classDef dsp fill:#1f2937,stroke:#60a5fa,color:#e5e7eb
     classDef io fill:#111827,stroke:#9ca3af,color:#e5e7eb
     classDef control fill:#111827,stroke:#9ca3af,color:#e5e7eb

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,11 @@
 
 use crossbeam_channel::{Receiver, Sender};
 use nih_plug::prelude::*;
-use nih_plug_egui::{create_egui_editor, egui, widgets, EguiState};
+use nih_plug_egui::{EguiState, create_egui_editor, egui, widgets};
 use parking_lot::{Mutex, RwLock};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use strum::IntoEnumIterator;
 
 // Make sure our modules are declared
@@ -270,7 +270,8 @@ impl Plugin for OpenHeadstagePlugin {
 
     fn editor(&mut self, _async_executor: AsyncExecutor<Self>) -> Option<Box<dyn Editor>> {
         let params = self.params.clone();
-        let editor_state = EditorState::new(self.gui_task_sender.clone(), self.auto_eq_result.clone());
+        let editor_state =
+            EditorState::new(self.gui_task_sender.clone(), self.auto_eq_result.clone());
 
         create_egui_editor(
             self.params.editor_state.clone(),
@@ -363,15 +364,21 @@ impl Plugin for OpenHeadstagePlugin {
                             for (i, band_param) in params.eq_bands.iter().enumerate() {
                                 if let Some(band_setting) = bands.get(i) {
                                     setter.set_parameter(&band_param.enabled, true);
-                                    setter.set_parameter(&band_param.filter_type, band_setting.filter_type);
-                                    setter.set_parameter(&band_param.frequency, band_setting.frequency);
+                                    setter.set_parameter(
+                                        &band_param.filter_type,
+                                        band_setting.filter_type,
+                                    );
+                                    setter.set_parameter(
+                                        &band_param.frequency,
+                                        band_setting.frequency,
+                                    );
                                     setter.set_parameter(&band_param.q, band_setting.q);
                                     setter.set_parameter(&band_param.gain, band_setting.gain);
                                 } else {
                                     setter.set_parameter(&band_param.enabled, false);
                                 }
                             }
-                            
+
                             for band_param in params.eq_bands.iter() {
                                 setter.end_set_parameter(&band_param.gain);
                                 setter.end_set_parameter(&band_param.q);


### PR DESCRIPTION
The previous Mermaid diagram was visually cluttered. This commit refactors the diagram's structure to create a clear, top-down flow.

- Separates the "User Controls" and "Configuration" from the "Signal Path".
- Uses a horizontal layout for the signal path to better represent the flow of audio.
- Improves overall readability and makes the architecture easier to understand.